### PR TITLE
Fix logs folder missing bug

### DIFF
--- a/.idea/archangel-master.iml
+++ b/.idea/archangel-master.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.9 (archangel-1)" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (archangel-1)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (archangel)" project-jdk-type="Python SDK" />
   <component name="PyCharmProfessionalAdvertiser">
     <option name="shown" value="true" />
   </component>

--- a/MyLogger.py
+++ b/MyLogger.py
@@ -12,6 +12,9 @@ class MyLogger:
         if not os.path.isdir(dirname):
             os.mkdir(dirname)
 
+        if cls._logger is not None:
+            return cls._logger
+            
         cls._logger = logging.getLogger("archangel")
         logging.basicConfig(
             filename=f'logs/{datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")}.log',

--- a/MyLogger.py
+++ b/MyLogger.py
@@ -1,0 +1,22 @@
+import logging
+import os
+import datetime
+
+
+class MyLogger:
+    _logger = None
+
+    def __new__(cls, *args, **kwargs):
+        dirname = "./logs"
+
+        if not os.path.isdir(dirname):
+            os.mkdir(dirname)
+
+        cls._logger = logging.getLogger("archangel")
+        logging.basicConfig(
+            filename=f'logs/{datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")}.log',
+            filemode='w',
+            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO
+        )
+
+        return cls._logger

--- a/angel.py
+++ b/angel.py
@@ -25,21 +25,11 @@ Distance (or whether an edge exists between two nodes) is a function of:
 import csv
 import time
 import random
-import logging
-import datetime
-# # FROMS
+
+# FROMS
+from MyLogger import MyLogger
 from models import Player
 from arrange import angel_mortal_arrange
-
-logger = logging.getLogger(__name__)
-logging.basicConfig(
-    filename=f'logs/{datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")}.log',
-    filemode='w',
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO
-)
-
-
-
 
 # GLOBALS
 PLAYERFILE = "playerlist.csv"
@@ -52,7 +42,8 @@ GENDER_NOPREF = "no preference"
 
 GENDER_SWAP_PREFERENCE_PERCENTAGE = 0.0 #100 if you wanna change all players with no gender pre to have genderpref = opposite gender, 0 if you wanna all to remain as no geneder pref
 
-
+# Get Logger
+logger = MyLogger()
 
 
 def read_csv(filename):

--- a/arrange.py
+++ b/arrange.py
@@ -1,24 +1,16 @@
+# IMPORTS
+import networkx as nx
+import time
+import random
+
 # FROMS
-from models import Player
+from MyLogger import MyLogger
 from graph import get_graph_from_edges, draw_graph, get_full_cycles_from_graph,\
     full_cycle_to_edges, get_one_full_cycle, convert_full_cycle_to_graph,\
     get_one_full_cycle_from_graph, get_hamiltonian_path_from_graph,\
     is_there_definitely_no_hamiltonian_cycle, hamilton
-
-import datetime
-import logging
-logger = logging.getLogger(__name__)
-logging.basicConfig(
-    filename=f'logs/{datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")}.log',
-    filemode='w',
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO
-)
-
-import networkx as nx
-import time
-import random
-# from random import shuffle
 from random import randint
+
 
 # Constants
 GENDER_MALE = "male"
@@ -41,6 +33,9 @@ RELAX_NO_SAME_HOUSE_REQUIREMENT_PERCENTAGE = 0.35
 RELAX_NO_SAME_CG_REQUIREMENT_PERCENTAGE = 0.00
 
 # RELAX_NO_SAME_FACULTY_REQUIREMENT_PERCENTAGE = 0.00 #not used
+
+# Get Logger
+logger = MyLogger()
 
 
 def get_house_from_player(player):

--- a/graph.py
+++ b/graph.py
@@ -3,16 +3,6 @@ import matplotlib.pyplot as plt
 from random import sample
 from networkx.algorithms.tournament import hamiltonian_path
 
-# import datetime
-# import logging
-# logger = logging.getLogger(__name__)
-# logging.basicConfig(
-#     filename=f'logs/{datetime.datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S")}.log',
-#     filemode='w',
-#     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO
-# )
-
-
 def draw_graph(G, labels=None, graph_layout='spring',
                node_size=1600, node_color='blue', node_alpha=0.3,
                node_text_size=9,


### PR DESCRIPTION
- Created a new file for logger configuration
- Python logger lib dictates that loggers sharing the same name would refer to the same object, thus this follows the singleton pattern
- Added check for missing directory